### PR TITLE
DM-29599: CONFIG_SCHEMA: flatten the schema

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -6,8 +6,23 @@
 Version History
 ###############
 
+v0.7.0
+------
+
+Changes:
+
+* Change the CSC configuration schema to allow configuring all algorithms at once.
+  This supports a planned change to how configuration files are read.
+
+Requires:
+
+* ts_salobj 6.3
+* ts_config_mttcs
+* ts_simactuators 2
+* IDL files for MTDomeTrajectory, MTDome, and MTMount built from ts_xml 8.1.
+
 v0.6.0
-======
+------
 
 Changes:
 
@@ -28,7 +43,7 @@ Requires:
 * IDL files for MTDomeTrajectory, MTDome, and MTMount built from ts_xml 8.1.
 
 v0.5.0
-======
+------
 
 Changes:
 
@@ -44,7 +59,7 @@ Requires:
 * IDL files for MTDomeTrajectory, MTDome, and MTMount built from ts_xml 7.1.
 
 v0.4.1
-======
+------
 
 Changes:
 
@@ -60,7 +75,7 @@ Requires:
 * IDL files for MTDomeTrajectory, MTDome, and MTMount built from ts_xml 7.1.
 
 v0.4.0
-======
+------
 
 Changes:
 
@@ -76,7 +91,7 @@ Requires:
 * IDL files for MTDomeTrajectory, MTDome, and MTMount built from ts_xml 7.1.
 
 v0.3.0
-======
+------
 
 Changes:
 
@@ -91,7 +106,7 @@ Requires:
 * IDL files for MTDomeTrajectory and MTDome
 
 v0.2.1
-======
+------
 
 Changes:
 
@@ -106,7 +121,7 @@ Requires:
 * IDL files for MTDomeTrajectory and MTDome
 
 v0.2.0
-======
+------
 
 Changes:
 
@@ -120,7 +135,7 @@ Requires:
 * IDL files for MTDomeTrajectory and MTDome
 
 v0.1.4
-======
+------
 
 Changes:
 
@@ -134,7 +149,7 @@ Requires:
 * IDL files for MTDomeTrajectory and Dome
 
 v0.1.3
-======
+------
 
 Changes:
 
@@ -149,7 +164,7 @@ Requires:
 * IDL files for MTDomeTrajectory and Dome
 
 v0.1.2
-======
+------
 
 Changes:
 

--- a/python/lsst/ts/MTDomeTrajectory/config_schema.py
+++ b/python/lsst/ts/MTDomeTrajectory/config_schema.py
@@ -39,36 +39,26 @@ properties:
     default: simple
   algorithm_config:
     type: object
-allOf:
-# For each supported algorithm_name add a new if/then case below.
-# Warning: set the default values for each case at the algorithm_config level
-# (rather than deeper down on properties within algorithm_config),
-# so users can omit algorithm_config and still get proper defaults.
-- if:
+  simple:
+    description: Configuration for the "simple" algorithm.
+    type: object
     properties:
-      algorithm_name:
-        const: simple
-  then:
-    properties:
-      algorithm_config:
-        properties:
-          max_delta_azimuth:
-            type: number
-            description: ->
-              Maximum difference between dome and telescope azimuth before moving the dome (deg).
-              The default value is nearly where the dome vignettes the telescope.
-          max_delta_elevation:
-            type: number
-            description: ->
-              Maximum difference between dome and telescope elevation before moving the dome (deg)
-              The default value is nearly where the dome vignettes the telescope.
-        required:
-        - max_delta_azimuth
-        - max_delta_elevation
-        default:
-          max_delta_azimuth: 5
-          max_delta_elevation: 6
-        additionalProperties: false
+      max_delta_azimuth:
+        type: number
+        description: ->
+          Maximum difference between dome and telescope azimuth before moving the dome (deg).
+          The default value is nearly where the dome vignettes the telescope.
+        default: 5
+      max_delta_elevation:
+        type: number
+        description: ->
+          Maximum difference between dome and telescope elevation before moving the dome (deg)
+          The default value is nearly where the dome vignettes the telescope.
+        default: 6
+    required:
+    - max_delta_azimuth
+    - max_delta_elevation
+    additionalProperties: false
 additionalProperties: false
 """
 )

--- a/python/lsst/ts/MTDomeTrajectory/dome_trajectory.py
+++ b/python/lsst/ts/MTDomeTrajectory/dome_trajectory.py
@@ -172,12 +172,14 @@ class MTDomeTrajectory(salobj.ConfigurableCsc):
         config : `types.SimpleNamespace`
             Configuration, as described by `CONFIG_SCHEMA`
         """
-        self.algorithm = AlgorithmRegistry[config.algorithm_name](
-            **config.algorithm_config
-        )
+        algorithm_name = config.algorithm_name
+        if algorithm_name not in AlgorithmRegistry:
+            raise salobj.ExpectedError(f"Unknown algorithm {algorithm_name}")
+        algorithm_config = getattr(config, config.algorithm_name)
+        self.algorithm = AlgorithmRegistry[config.algorithm_name](**algorithm_config)
         self.evt_algorithm.set_put(
             algorithmName=config.algorithm_name,
-            algorithmConfig=yaml.dump(config.algorithm_config),
+            algorithmConfig=yaml.dump(algorithm_config),
         )
 
     async def handle_summary_state(self):

--- a/tests/data/config/invalid_bad_max_daz.yaml
+++ b/tests/data/config/invalid_bad_max_daz.yaml
@@ -1,3 +1,3 @@
 algorithm_name: "simple"
-algorithm_config:
+simple:
   max_delta_azimuth: "invalid value"

--- a/tests/data/config/invalid_no_such_algorithm_config_name.yaml
+++ b/tests/data/config/invalid_no_such_algorithm_config_name.yaml
@@ -2,3 +2,5 @@ algorithm_name: "simple"
 simple:
   max_delta_azimuth: 7.1
   max_delta_elevation: 5.5
+not_an_algorithm:
+  arbitrary_parameter_name: 7.1

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -36,11 +36,12 @@ class ValidationTestCase(unittest.TestCase):
         # Values copied from the schema
         self.default_config = dict(
             algorithm_name="simple",
-            algorithm_config=dict(max_delta_azimuth=5, max_delta_elevation=6),
+            simple=dict(max_delta_azimuth=5, max_delta_elevation=6),
         )
 
     def test_default(self):
         result = self.validator.validate(None)
+        print("result=", result)
         self.assertEqual(result["algorithm_name"], "simple")
         self.assertEqual(result, self.default_config)
 
@@ -55,11 +56,11 @@ class ValidationTestCase(unittest.TestCase):
         algorithm_config = dict(max_delta_azimuth=3.5, max_delta_elevation=2.2)
         data = dict(
             algorithm_name="simple",
-            algorithm_config=algorithm_config.copy(),
+            simple=algorithm_config.copy(),
         )
         result = self.validator.validate(data)
         self.assertEqual(result["algorithm_name"], "simple")
-        self.assertEqual(result["algorithm_config"], algorithm_config)
+        self.assertEqual(result["simple"], algorithm_config)
 
     def test_bad_algorithm_name(self):
         data = dict(algorithm_name="invalid_name")
@@ -68,7 +69,7 @@ class ValidationTestCase(unittest.TestCase):
 
     def test_bad_algorithm_config(self):
         """The current schema only checks for a dict."""
-        data = dict(algorithm_name="simple", algorithm_config=45)
+        data = dict(algorithm_name="simple", simple=45)
         with self.assertRaises(jsonschema.exceptions.ValidationError):
             self.validator.validate(data)
 


### PR DESCRIPTION
so that all values for all algorithms can be specified at the same time.
This is needed in order to support loading configuration data sequentially
from multiple files.