### PR TITLE
DM-36502: MockDome: fix ts_xml 12.1 compatibility

### DIFF
--- a/python/lsst/ts/mtdometrajectory/mock_dome.py
+++ b/python/lsst/ts/mtdometrajectory/mock_dome.py
@@ -89,7 +89,7 @@ class MockDome(salobj.BaseCsc):
             "park",
             "resetDrivesAz",
             "resetDrivesShutter",
-            "searchZeroShutter",
+            "home",
             "setLouvers",
             "setOperationalMode",
             "setTemperature",


### PR DESCRIPTION
Note: the version history needs no update because the version is already pending release of ts_xml 12.1 and the existing info was correct.